### PR TITLE
Preparation for v0.1.2-alpha

### DIFF
--- a/JSONSchema/gkisplus.json
+++ b/JSONSchema/gkisplus.json
@@ -19,31 +19,36 @@
                     "title": "PKJ 80 Getsemani Tempat Yesus Berdoa",
                     "date": "2020-04-07",
                     "link": "https://www.youtube.com/watch?v=UdhHB9u3dk4",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "NKB 84 Kubrikan Bagimu Tubuh Ku Darah Ku",
                     "date": "2020-04-07",
                     "link": "https://www.youtube.com/watch?v=wl6VM5_sodc",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "KJ 445 Harap Akan Tuhan",
                     "date": "2020-03-27",
                     "link": "https://www.youtube.com/watch?v=ST0wlc5eW0w",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "NKB 104 : 1, 3 Apinya Berkobar Dalam Hatiku ( Live Recording )",
                     "date": "2022-04-04",
                     "link": "https://www.youtube.com/watch?v=7abxafMJiHU",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "NKB 116 Siapa Yang Berpegang",
                     "date": "2020-03-27",
                     "link": "https://www.youtube.com/watch?v=9CY2WaDBFnQ",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_1.jpg",
+                    "is_live": 0
                 }
             ],
             "saren": [
@@ -51,65 +56,73 @@
                     "title": "SaRen Pagi | 19 Jul 2024",
                     "date": "2024-07-19",
                     "link": "https://www.youtube.com/watch?v=hOYF059QydY",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "SaRen Pagi | 18 Jul 2024 | Nggandhul Gusti",
                     "date": "2024-07-18",
                     "link": "https://www.youtube.com/watch?v=pmbowHpFzAk",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "SaRen Pagi | 17 Jul 2024",
                     "date": "2024-07-17",
                     "link": "https://www.youtube.com/watch?v=TbmjYNZ0kOc",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "SaRen Pagi | 16 Jul 2024",
                     "date": "2024-07-16",
                     "link": "https://www.youtube.com/watch?v=JIrzyNfZGxk",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg",
+                    "is_live": 0
                 },
                 {
                     "title": "SaRen Pagi | 8 Jul 2024",
                     "date": "2024-07-08",
                     "link": "https://www.youtube.com/watch?v=Lc1qvhMfbC8",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_2.jpg",
+                    "is_live": 0
                 }
-            ]
-        },
-        "yt-live": {
+            ],
             "umum": [
                 {
                     "title": "Ibadah Minggu GKI SALATIGA | 14 JULI 2024 | Pil Pahit Kebenaran",
                     "date": "2024-07-14",
                     "link": "https://www.youtube.com/watch?v=bqIVKLms3AI",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "Ibadah Minggu GKI SALATIGA | 7 JULI 2024 | Keteguhan Seorang Pembawa Pesan",
                     "date": "2024-07-07",
                     "link": "https://www.youtube.com/watch?v=BKmE5n2HtLA",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "Ibadah Minggu GKI SALATIGA | 7 JULI 2024 | Keteguhan Seorang Pembawa Pesan",
                     "date": "2024-07-07",
                     "link": "https://www.youtube.com/watch?v=fzp1QbFD-HM",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "Ibadah Minggu GKI SALATIGA | 16 JUNI 2024 | Kesetiaan Bertumbuh Setiap Hari | Jam 07.00 WIB",
                     "date": "2024-06-16",
                     "link": "https://www.youtube.com/watch?v=cDUFX23J2A4",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "Ibadah Minggu Pentakosta I GKI SALATIGA | 19 Mei 2024 | 07.00 WIB",
                     "date": "2024-05-19",
                     "link": "https://www.youtube.com/watch?v=YquHwKujRjE",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_3.jpg",
+                    "is_live": 1
                 }
             ],
             "es": [
@@ -117,19 +130,22 @@
                     "title": "English Service | August 7, 2022 | \"Those whom Jesus Welcomes\"",
                     "date": "2022-08-07",
                     "link": "https://www.youtube.com/watch?v=8XeDoiZxp2k",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "English Service GKI Salatiga | October 2, 2022 | \"I Have Changed\"",
                     "date": "2022-10-02",
                     "link": "https://www.youtube.com/watch?v=dy9P2mSu5V4",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg",
+                    "is_live": 1
                 },
                 {
                     "title": "GKI Salatiga | English Service | Sunday, February 4th. 2024 | 9 a.m. Jakarta Time",
                     "date": "2024-02-04",
                     "link": "https://www.youtube.com/watch?v=3_chreURsyk",
-                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg"
+                    "thumbnail": "https://raw.githubusercontent.com/groaking/groaking.github.io/main/playground/yt_sample_thumbnail_4.jpg",
+                    "is_live": 1
                 }
             ]
         },
@@ -196,6 +212,52 @@
                     "time": "17:00",
                     "place": "Wilayah masing-masing",
                     "representative": "Komisi PPK"
+                }
+            ],
+            "wed": [
+                {
+                    "name": "Pemahaman Alkitab Kambium",
+                    "time": "18:00",
+                    "place": "Ruang Konsistori",
+                    "representative": "Komisi Dewasa"
+                }
+            ],
+            "thu": [
+                {
+                    "name": "Latihan SODA",
+                    "time": "18:00",
+                    "place": "Ruang Kana",
+                    "representative": "Komisi Pemuda"
+                }
+            ],
+            "fri": [
+                {
+                    "name": "Latihan SODA",
+                    "time": "18:00",
+                    "place": "Ruang Kana",
+                    "representative": "Komisi Pemuda"
+                }
+            ],
+            "sat": [
+                {
+                    "name": "Persekutuan Sobat Muda (SODA)",
+                    "time": "17:00",
+                    "place": "Ruang Kana",
+                    "representative": "Komisi Pemuda"
+                },
+                {
+                    "name": "Latihan Kebaktian Remaja",
+                    "time": "20:00",
+                    "place": "Ruang Kana",
+                    "representative": "Komisi Remaja"
+                }
+            ],
+            "sun": [
+                {
+                    "name": "Kebaktian Umum I",
+                    "time": "07:00",
+                    "place": "Gedung Utama GKI Salatiga",
+                    "representative": "Majelis Jemaat"
                 }
             ]
         },


### PR DESCRIPTION
Merged "yt-live" with "yt-video", only discerning live from pre-recorded videos by the "is_live" property in each item. This is done due to the proposed change to merge live and pre-recorded videos into "services" tab in the next update.