### PR TITLE
Fixing "targeting S+ version 31 and above" error.

### DIFF
--- a/AndroidStudioProject/app/build.gradle
+++ b/AndroidStudioProject/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "org.gkisalatiga.plus"
         minSdk 21
         targetSdk 33
-        versionCode 20
-        versionName "0.3.0-beta"
+        versionCode 21
+        versionName "0.3.1-beta.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -121,11 +121,14 @@ dependencies {
 
     // For displaying icons on tabs?
     // SOURCE: https://stackoverflow.com/q/78398074
-    implementation(platform("androidx.compose:compose-bom"))
+    // implementation(platform("androidx.compose:compose-bom"))
 
     // To allow WorkManager to start background services and works, even after device restart.
     // SOURCE: https://medium.com/@denniskirimi.dk/android-workmanager-37e08c070439
-    implementation ("androidx.work:work-runtime-ktx:2.9.1")
+    // ---
+    // Don't enable to avoid "targeting S+ version 31 and above" error.
+    // SOURCE: https://stackoverflow.com/a/69152986
+    // implementation ("androidx.work:work-runtime-ktx:2.9.1")
 
     // For displaying notifications.
     // implementation ("com.android.support:support-compat")

--- a/AndroidStudioProject/app/release/output-metadata.json
+++ b/AndroidStudioProject/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 20,
-      "versionName": "0.3.0-beta",
+      "versionCode": 21,
+      "versionName": "0.3.1-beta.2",
       "outputFile": "app-release.apk"
     }
   ],

--- a/AndroidStudioProject/app/src/main/java/org/gkisalatiga/plus/services/AlarmService.kt
+++ b/AndroidStudioProject/app/src/main/java/org/gkisalatiga/plus/services/AlarmService.kt
@@ -32,7 +32,9 @@ class AlarmService {
             val notifyIntent = Intent(ctx, AlarmReceiver::class.java)
             notifyIntent.putExtra("host", AlarmRoutes.ALARM_SAREN)
 
-            val alarmIntent: PendingIntent = PendingIntent.getBroadcast(ctx, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            // Use "FLAG_MUTABLE" to avoid "targeting S+ version 31 and above" error.
+            // SOURCE: https://stackoverflow.com/a/69235587
+            val alarmIntent: PendingIntent = PendingIntent.getBroadcast(ctx, 0, notifyIntent, PendingIntent.FLAG_MUTABLE)
             val alarmMgr: AlarmManager = ctx.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
             alarmMgr.setInexactRepeating(
@@ -62,7 +64,9 @@ class AlarmService {
             val notifyIntent = Intent(ctx, AlarmReceiver::class.java)
             notifyIntent.putExtra("host", AlarmRoutes.ALARM_YKB_HARIAN)
 
-            val alarmIntent: PendingIntent = PendingIntent.getBroadcast(ctx, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            // Use "FLAG_MUTABLE" to avoid "targeting S+ version 31 and above" error.
+            // SOURCE: https://stackoverflow.com/a/69235587
+            val alarmIntent: PendingIntent = PendingIntent.getBroadcast(ctx, 0, notifyIntent, PendingIntent.FLAG_MUTABLE)
             val alarmMgr: AlarmManager = ctx.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
             alarmMgr.setInexactRepeating(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GKI Salatiga+ Changelog
 
+## v0.3.1-beta.2 (21) --- 2024-08-16
+
+- Fix: Fixed "targeting S+ version 31 and above" error on HyperOS devices
+
 ## v0.3.0-beta (20) --- 2024-08-16
 
 - New: The event documentation gallery feature has now been introduced


### PR DESCRIPTION
- Fix: Fixed "targeting S+ version 31 and above" error on HyperOS devices

Co-Authored-By: Jeff <natanaeljeffrey@gmail.com>